### PR TITLE
added vue config to reset server on editing vue files

### DIFF
--- a/accessibuild-front/vue.config.js
+++ b/accessibuild-front/vue.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  configureWebpack: {
+    devServer: {
+      watchOptions: {
+        ignored: /node_modules/,
+        poll: 1000
+      }
+    }
+  }
+}


### PR DESCRIPTION
Vue config file should now ensure the server resets when chages are made to the client-side code. This wasn't working before because of an issue with vagrant.